### PR TITLE
Fix #27: Corrige Overflow entre botones de detalles

### DIFF
--- a/lib/Envios/ui/widgets/form_dialog_detalle_envios.dart
+++ b/lib/Envios/ui/widgets/form_dialog_detalle_envios.dart
@@ -3,6 +3,15 @@ import 'package:suenomotora_app/common/widgets/forms_elements.dart';
 
 class FormDialogDetalleEnvio extends StatefulWidget {
   const FormDialogDetalleEnvio({Key? key}) : super(key: key);
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTablet(context);
+    }
+  }
 
   Future formDialogDetalleEnvio(BuildContext context) {
     FormsElements formsElements = FormsElements();
@@ -32,7 +41,7 @@ class FormDialogDetalleEnvio extends StatefulWidget {
                     formsElements.createInput('Telefono', 'Telefono'),
                     formsElements.boxImput(
                         'Contenido de envio', 'Contenido de envio'),
-                    formsElements.btnsformDetalles(context)
+                    responsiveButtons(context)
                   ]),
             ),
           ),

--- a/lib/Equipos/ui/widgets/form_dialog_detalle_equipo.dart
+++ b/lib/Equipos/ui/widgets/form_dialog_detalle_equipo.dart
@@ -3,6 +3,15 @@ import 'package:suenomotora_app/common/widgets/forms_elements.dart';
 
 class FormDialogDetalleEquipos extends StatefulWidget {
   const FormDialogDetalleEquipos({Key? key}) : super(key: key);
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTablet(context);
+    }
+  }
 
   static formDialogDetalleEquipos(BuildContext context) {
     FormsElements formsElements = FormsElements();
@@ -22,7 +31,7 @@ class FormDialogDetalleEquipos extends StatefulWidget {
                   formsElements.createInput('RAM', 'RAM'),
                   formsElements.createInput('Disco Duro', 'Disco Duro'),
                   formsElements.boxImput('Observaciones', 'observaciones'),
-                  formsElements.btnsformDetalles(context)
+                  responsiveButtons(context)
                 ]),
               ),
             ]);

--- a/lib/Map/ui/widgets/form_dialog_Detalles_ubicación.dart
+++ b/lib/Map/ui/widgets/form_dialog_Detalles_ubicación.dart
@@ -5,6 +5,15 @@ import 'package:swipe_image_gallery/swipe_image_gallery.dart';
 
 class FormDialogDetallesUbicacion extends StatefulWidget {
   const FormDialogDetallesUbicacion({Key? key}) : super(key: key);
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTabletUbicacion(context);
+    }
+  }
 
   static formDialogDetallesUbicacion(BuildContext context) {
     FormsElements formsElements = FormsElements();
@@ -33,13 +42,13 @@ class FormDialogDetallesUbicacion extends StatefulWidget {
       useSafeArea: true,
       builder: (context) {
         return SizedBox(
-          width: 1000,
+          width: 600,
           child: SimpleDialog(
               title: const Text('Detalles de Ubicación',
                   textAlign: TextAlign.center),
               children: [
                 SizedBox(
-                  width: MediaQuery.of(context).size.width * 100,
+                  width: MediaQuery.of(context).size.width * 0.5,
                   child: Padding(
                     padding: const EdgeInsets.all(10.0),
                     child: Column(
@@ -97,6 +106,7 @@ class FormDialogDetallesUbicacion extends StatefulWidget {
                         ),
                       ],
                     )),
+                responsiveButtons(context)
               ]),
         );
       },

--- a/lib/Persona/Colaborador/ui/widgets/form_diaglog_detalles_colaboradores.dart
+++ b/lib/Persona/Colaborador/ui/widgets/form_diaglog_detalles_colaboradores.dart
@@ -5,55 +5,40 @@ import 'package:suenomotora_app/common/widgets/forms_elements.dart';
 class FormDialogDetallesColaborador extends StatefulWidget {
   const FormDialogDetallesColaborador({Key? key}) : super(key: key);
 
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTablet(context);
+    }
+  }
+
   static formDialogDetallesColaborador(BuildContext context) {
     FormsElements formsElements = FormsElements();
 
     return showDialog(
       context: context,
       barrierDismissible: true,
+      useSafeArea: true,
       builder: (context) {
         return SimpleDialog(
-            title: const Text('Registro de colaboradores'),
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(10.0),
-                child:
-                    Column(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  formsElements.createInput('Nombre', 'nombre'),
-                  formsElements.createInput('Telefono', 'Telefono'),
-                  formsElements.createInput(
-                      'Correo electronico', 'Correo electronico'),
-                  Padding(
-                    padding: const EdgeInsets.all(20.0),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Actualizar')),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Eliminar')),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Cancelar')),
-                        ),
-                      ],
-                    ),
-                  ),
-                ]),
-              ),
-            ]);
+          title: const Text('Registro de colaboradores'),
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(10.0),
+              child:
+                  Column(mainAxisAlignment: MainAxisAlignment.end, children: [
+                formsElements.createInput('Nombre', 'nombre'),
+                formsElements.createInput('Telefono', 'Telefono'),
+                formsElements.createInput(
+                    'Correo electronico', 'Correo electronico'),
+                responsiveButtons(context)
+              ]),
+            ),
+          ],
+        );
       },
     );
   }

--- a/lib/Persona/Donante/ui/widgets/form_diaglog_detalles_donantes.dart
+++ b/lib/Persona/Donante/ui/widgets/form_diaglog_detalles_donantes.dart
@@ -4,6 +4,15 @@ import 'package:suenomotora_app/common/widgets/forms_elements.dart';
 
 class FormDialogDetallesDonantes extends StatefulWidget {
   const FormDialogDetallesDonantes({Key? key}) : super(key: key);
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTablet(context);
+    }
+  }
 
   static formDialogDetallesDonantes(BuildContext context) {
     FormsElements formsElements = FormsElements();
@@ -23,7 +32,7 @@ class FormDialogDetallesDonantes extends StatefulWidget {
                   formsElements.createInput('Telefono', 'Telefono'),
                   formsElements.createInput(
                       'Correo electronico', 'Correo electronico'),
-                  formsElements.btnsformDetalles(context)
+                  responsiveButtons(context)
                 ]),
               ),
             ]);

--- a/lib/Solicitudes/ui/widgets/forms_dialog_detalle_solicitudes_escuelas.dart
+++ b/lib/Solicitudes/ui/widgets/forms_dialog_detalle_solicitudes_escuelas.dart
@@ -3,6 +3,15 @@ import 'package:suenomotora_app/common/widgets/forms_elements.dart';
 
 class FormDialogDetalleSolicitudEscuela extends StatefulWidget {
   const FormDialogDetalleSolicitudEscuela({Key? key}) : super(key: key);
+  static responsiveButtons(context) {
+    FormsElements formsElements = FormsElements();
+
+    if (MediaQuery.of(context).size.width <= 600) {
+      return formsElements.btnsDetallesMovil(context);
+    } else {
+      return formsElements.btnsDetallesDesktopTablet(context);
+    }
+  }
 
   static formDialogDetalleSolicitudEscuela(BuildContext context) {
     FormsElements formsElements = FormsElements();
@@ -25,33 +34,7 @@ class FormDialogDetalleSolicitudEscuela extends StatefulWidget {
                   formsElements.createInput(
                       'Correo electronico', 'Correo electronico'),
                   formsElements.boxImput('Solicitud', '¿Qué solicita?'),
-                  Padding(
-                    padding: const EdgeInsets.all(30.0),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Actualizar')),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Eliminar')),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ElevatedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('Cancelar')),
-                        ),
-                      ],
-                    ),
-                  ),
+                  responsiveButtons(context)
                 ]),
               ),
             ]);

--- a/lib/common/widgets/forms_elements.dart
+++ b/lib/common/widgets/forms_elements.dart
@@ -103,33 +103,104 @@ class FormsElements extends StatelessWidget {
     );
   }
 
-  Widget btnsformDetalles(context) {
+  Widget btnsDetallesDesktopTablet(context) {
     return SizedBox(
       height: 100,
       width: 400,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: 100,
-            child: ElevatedButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const AutoSizeText('Actualizar')),
-          ),
-          SizedBox(
-              width: 100,
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
               child: ElevatedButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: const AutoSizeText('Eliminar'))),
-          SizedBox(
-            width: 100,
-            child: ElevatedButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('Aceptar')),
+                  child: const AutoSizeText('Actualizar')),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
+                child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const AutoSizeText('Eliminar'))),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
+              child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Aceptar')),
+            ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget btnsDetallesDesktopTabletUbicacion(context) {
+    return SizedBox(
+      height: 100,
+      width: MediaQuery.of(context).size.width * 0.1,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
+              child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const AutoSizeText('Actualizar')),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
+                child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const AutoSizeText('Eliminar'))),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Expanded(
+              child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Aceptar')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget btnsDetallesMovil(context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 15.0),
+      child: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              onPressed: () => Navigator.of(context).pop(),
+              icon: const Icon(Icons.edit, color: Colors.green),
+            ),
+            IconButton(
+              onPressed: () => Navigator.of(context).pop(),
+              icon: const Icon(Icons.delete, color: Colors.red),
+            ),
+            IconButton(
+              onPressed: () => Navigator.of(context).pop(),
+              icon: const Icon(Icons.cancel, color: Colors.grey),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Corrige el overflow que se producía en la vista móvil, debido a que el
espacio disponible en el formulario de detalles no era suficiente para
dibujar los botones completamente. Por lo que se cambio estos botones
por unos iconos en la vista movil.